### PR TITLE
Don't override SSHKit.config.command_map

### DIFF
--- a/lib/capistrano/tasks/chruby.rake
+++ b/lib/capistrano/tasks/chruby.rake
@@ -2,22 +2,10 @@ def bundler_loaded?
   Gem::Specification::find_all_by_name('capistrano-bundler').any?
 end
 
-SSHKit.config.command_map = Hash.new do |hash, key|
-  if fetch(:chruby_map_bins).include?(key.to_s)
-    prefix = "#{fetch(:chruby_exec)} #{fetch(:chruby_ruby)} --"
-    hash[key] = if bundler_loaded? && key.to_s != "bundle"
-      "#{prefix} bundle exec #{key}"
-    else
-      "#{prefix} #{key}"
-    end
-  else
-    hash[key] = key
-  end
-end
-
 namespace :deploy do
   before :starting, :hook_chruby_bins do
     invoke :'chruby:check'
+    invoke :'chruby:command_map'
   end
 end
 
@@ -28,6 +16,20 @@ namespace :chruby do
       if chruby_ruby.nil?
         error "chruby: chruby_ruby is not set"
         exit 1
+      end
+    end
+  end
+
+  task :command_map do
+    on roles(:all) do
+      fetch(:chruby_map_bins).each do |bin|
+        prefix = "#{fetch(:chruby_exec)} #{fetch(:chruby_ruby)} --"
+        bundle_exec = bundler_loaded? && bin.to_s != "bundle"
+        SSHKit.config.command_map[bin.to_sym] = if bundle_exec
+          "#{prefix} bundle exec #{bin}"
+        else
+          "#{prefix} #{bin}"
+        end
       end
     end
   end


### PR DESCRIPTION
[SSHKit's documentation](https://github.com/leehambley/sshkit/blob/4c0694a96f445f27209cc56b576cd998c6e4b658/README.md#the-command-map) says it's not wise to override it:

> One can also override the command map completely, this may not be wise,
> but it would be possible, for example:
> 
> SSHKit.config.command_map = Hash.new do |hash, command|
>   hash[command] = "/usr/local/rbenv/shims/#{command}"
> end
