### PR TITLE
update sshkit dependency

### DIFF
--- a/capistrano-chruby.gemspec
+++ b/capistrano-chruby.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'capistrano', '~> 3.0'
-  gem.add_dependency 'sshkit', '~> 1.2.0'
+  gem.add_dependency 'sshkit', '~> 1.3'
 
 end


### PR DESCRIPTION
I had to update this to get the latest version of capistrano-bundler installed. I guess because that gem specifies ~> 1.3.0 too?
