### PR TITLE
Issue with Capistrano calling shell script that depends on Ruby

### DIFF
--- a/lib/capistrano/tasks/chruby.rake
+++ b/lib/capistrano/tasks/chruby.rake
@@ -10,6 +10,8 @@ namespace :chruby do
 
   task :map_bins do
     chruby_prefix = "#{fetch(:chruby_exec)} #{fetch(:chruby_ruby)} --"
+    
+    SSHKit.config.command_map[:chruby_prefix] = chruby_prefix
 
     fetch(:chruby_map_bins).each do |command|
       SSHKit.config.command_map.prefix[command.to_sym].unshift(chruby_prefix)


### PR DESCRIPTION
Chruby works great, but I'm having an issue when trying to use Ruby in a shell script that Capistrano calls:

``` bash
#!/usr/bin/env sh
# ...snip...
ruby --something
# ...snip...
```

It runs in a Capistrano task like this:

``` ruby
task :that_calls_shell_script do
    on roles(:app) do
      within release_path do
          execute "path/to/shell/script"
      end
    end
  end
```

The problem is, if I understand correctly, that Capistrano Chruby only seems to call Chruby through `chruby-exec`, which is nice and self-contained, but a problem when you need the Chruby environment there for other purposes.

Is there some kind of workaround?
